### PR TITLE
fix: interface를 implement하는 타입에 대응 [DEV-6655]

### DIFF
--- a/build/utilities/ast-filter.js
+++ b/build/utilities/ast-filter.js
@@ -10,9 +10,15 @@ const filterOnlyVisitedSchema = ({ ast, visitedSchemaNodeNames, schemaNodeNamesT
         enter(node) {
             if (!(node.kind === graphql_1.Kind.DIRECTIVE_DEFINITION ||
                 node.kind === graphql_1.Kind.SCALAR_TYPE_DEFINITION ||
-                node.kind === graphql_1.Kind.ENUM_TYPE_DEFINITION ||
                 node.kind === graphql_1.Kind.OBJECT_TYPE_DEFINITION ||
                 node.kind === graphql_1.Kind.INPUT_OBJECT_TYPE_DEFINITION)) {
+                return node;
+            }
+            /**
+             * interface를 implement하는 type이라면, API에서 방문하지 않을 수 있습니다.
+             * 따라서 강제로 추가해 줍니다.
+             */
+            if (node.kind == graphql_1.Kind.OBJECT_TYPE_DEFINITION && node.interfaces.length > 0) {
                 return node;
             }
             const { name: { value: name }, } = node;

--- a/lib/utilities/ast-filter.ts
+++ b/lib/utilities/ast-filter.ts
@@ -20,11 +20,18 @@ export const filterOnlyVisitedSchema = ({
         !(
           node.kind === Kind.DIRECTIVE_DEFINITION ||
           node.kind === Kind.SCALAR_TYPE_DEFINITION ||
-          node.kind === Kind.ENUM_TYPE_DEFINITION ||
           node.kind === Kind.OBJECT_TYPE_DEFINITION ||
           node.kind === Kind.INPUT_OBJECT_TYPE_DEFINITION
         )
       ) {
+        return node;
+      }
+
+      /**
+       * interface를 implement하는 type이라면, API에서 방문하지 않을 수 있습니다.
+       * 따라서 강제로 추가해 줍니다.
+       */
+      if (node.kind == Kind.OBJECT_TYPE_DEFINITION && node.interfaces.length > 0) {
         return node;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema-filter",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "given schema, this package extracts all available queries, mutations, subscriptions and then make list of those to determine whether to use each graphql operation, by using that filters, reduced-schema is generated",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- updated version to 1.0.9
- [ast-filter] enum은 강제로 포함하도록 함
- [ast-filter] interface를 implement하는 object type은 강제로 포함하도록 함